### PR TITLE
サービス名に一致する場合のみ情報を表示

### DIFF
--- a/step2/password_output.sh
+++ b/step2/password_output.sh
@@ -2,7 +2,7 @@ read -p "サービスを入力してください:" service_name
 output_service_name=$(grep $service_name password_save_file | cut -d":" -f1)
 output_user_name=$(grep $service_name password_save_file | cut -d":" -f2)
 output_password=$(grep $service_name password_save_file | cut -d":" -f3)
-if grep -q $service_name password_save_file; then
+if awk -F ":" '{print $1}' password_save_file | grep -x -q "$service_name" ; then
 	echo "サービス名:"$output_service_name
 	echo "ユーザー名:"$output_user_name
 	echo "パスワード:"$output_password


### PR DESCRIPTION
・変更前の状態では、サービス名が他のpasswordに含まれている場合でも情報が表示されていた。
・変更後の状態では、サービス名が完全に一致する場合のみ情報が表示されるようにした。